### PR TITLE
Add ACL and redirect for api.turbovote.org/users

### DIFF
--- a/conf.json
+++ b/conf.json
@@ -100,8 +100,9 @@
         "use_backend turbovote_staging if is_turbovote_staging",
         "acl is_online_voter_reg_api hdr_end(host) -i online-voter-reg-api.turbovote.org",
         "use_backend online_voter_reg_api if is_online_voter_reg_api",
-        "acl is_user_http_api base_beg api.turbovote.org/users",
-        "use_backend user_http_api if is_user_http_api"
+        "acl is_api_server hdr(host) -i api.turbovote.org",
+        "acl is_user_api url_beg -i /users",
+        "use_backend user_http_api if is_api_server is_user_api"
       ],
       "backend ballot_scout": [
         "mode http",

--- a/conf.json
+++ b/conf.json
@@ -100,7 +100,7 @@
         "use_backend turbovote_staging if is_turbovote_staging",
         "acl is_online_voter_reg_api hdr_end(host) -i online-voter-reg-api.turbovote.org",
         "use_backend online_voter_reg_api if is_online_voter_reg_api",
-        "acl is_user_http_api base_beg -i api.turbobote.org/users",
+        "acl is_user_http_api base_beg api.turbovote.org/users",
         "use_backend user_http_api if is_user_http_api"
       ],
       "backend ballot_scout": [

--- a/conf.json
+++ b/conf.json
@@ -100,7 +100,7 @@
         "use_backend turbovote_staging if is_turbovote_staging",
         "acl is_online_voter_reg_api hdr_end(host) -i online-voter-reg-api.turbovote.org",
         "use_backend online_voter_reg_api if is_online_voter_reg_api",
-        "acl is_user_http_api base -i ^api[.]turbobote[.]org/users.*",
+        "acl is_user_http_api base_beg -i api.turbobote.org/users",
         "use_backend user_http_api if is_user_http_api"
       ],
       "backend ballot_scout": [

--- a/conf.json
+++ b/conf.json
@@ -99,7 +99,9 @@
         "acl is_turbovote_staging hdr_end(host) -i turbovote.net",
         "use_backend turbovote_staging if is_turbovote_staging",
         "acl is_online_voter_reg_api hdr_end(host) -i online-voter-reg-api.turbovote.org",
-        "use_backend online_voter_reg_api if is_online_voter_reg_api"
+        "use_backend online_voter_reg_api if is_online_voter_reg_api",
+        "acl is_user_http_api base -i ^api[.]turbobote[.]org/users.*",
+        "use_backend user_http_api if is_user_http_api"
       ],
       "backend ballot_scout": [
         "mode http",
@@ -112,6 +114,14 @@
       "backend address": [
         "mode http",
         "reqrep ^([^\\ ]*)\\ (.+)    \\1\\ /address-works\\2",
+        "balance roundrobin",
+        "option httpclose",
+        "option forwardfor",
+        "server local localhost:8081 maxconn 32"
+      ],
+      "backend user_http_api": [
+        "mode http",
+        "reqrep ^([^\\ ]*)\\ /users(.+)    \\1\\ /user-http-api\\2",
         "balance roundrobin",
         "option httpclose",
         "option forwardfor",


### PR DESCRIPTION
It should redirect to /user-http-api on one of the wildflies.

That is

```
http://api.turbovote.org/users/stuff => http://wildfly1/user-http-api/stuff
```

[Pivotal Card](https://www.pivotaltracker.com/story/show/99939626)