### PR TITLE
Add election-mail

### DIFF
--- a/conf.json
+++ b/conf.json
@@ -127,7 +127,9 @@
         "acl is_partners_api url_beg -i /partners",
         "use_backend partners_api if is_api_server is_partners_api",
         "acl is_election_api url_beg -i /elections",
-        "use_backend election_api if is_api_server is_election_api"
+        "use_backend election_api if is_api_server is_election_api",
+        "acl is_election_mail_api url_beg -i /election-mail",
+        "use_backend election_mail_api if is_api_server is_election_mail_api"
       ],
       "backend ballot_scout": [
         "mode http",
@@ -227,6 +229,14 @@
       "backend election_api": [
         "mode http",
         "reqrep ^([^\\ ]*)\\ /elections(.+)    \\1\\ /election-http-api\\2",
+        "balance roundrobin",
+        "option httpclose",
+        "option forwardfor",
+        "server local localhost:8081 maxconn 32"
+      ],
+      "backend election_mail_api": [
+        "mode http",
+        "reqrep ^([^\\ ]*)\\ /election-mail(.+)    \\1\\ /election-mail-http-api\\2",
         "balance roundrobin",
         "option httpclose",
         "option forwardfor",


### PR DESCRIPTION
This adds election-mail to the load balancer and fixed the previous parse issues. Tested locally to verify that conf.json will parse.