### PR TITLE
Multiple config file support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,14 +13,16 @@ RUN bundle config build.nokogiri --use-system-libraries
 RUN mkdir -p /usr/src/synapse-balancer
 WORKDIR /usr/src/synapse-balancer
 
-ADD Gemfile Gemfile
-ADD Gemfile.lock Gemfile.lock
+COPY Gemfile Gemfile
+COPY Gemfile.lock Gemfile.lock
 RUN bundle install --system
 
-ADD start-synapse.sh start-synapse.sh
-ADD conf.json conf.json
+COPY start-synapse.sh start-synapse.sh
+COPY conf conf
 
 EXPOSE 80
 EXPOSE 8080
 
-CMD ["/usr/src/synapse-balancer/start-synapse.sh"]
+ENTRYPOINT ["/usr/src/synapse-balancer/start-synapse.sh"]
+
+CMD ["conf.json"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,4 @@ EXPOSE 8080
 
 ENTRYPOINT ["/usr/src/synapse-balancer/start-synapse.sh"]
 
-CMD ["conf.json"]
+CMD ["config.json"]

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source 'https://rubygems.org/'
 
-gem 'synapse', github: 'democracyworks/synapse', branch: 'v0.12.1-democracyworks'
+gem 'synapse', '~> 0.13.8'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,3 @@
-GIT
-  remote: git://github.com/democracyworks/synapse.git
-  revision: 2f465bcdc35a196197ccc4becdf3fe38dc305a3c
-  branch: v0.12.1-democracyworks
-  specs:
-    synapse (0.12.1)
-      aws-sdk (~> 1.39)
-      docker-api (~> 1.7)
-      logging (~> 1.8)
-      zk (~> 1.9.4)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -17,19 +6,24 @@ GEM
     aws-sdk-v1 (1.66.0)
       json (~> 1.4)
       nokogiri (>= 1.4.4)
-    docker-api (1.26.0)
+    docker-api (1.33.1)
       excon (>= 0.38.0)
       json
-    excon (0.45.4)
+    excon (0.54.0)
     json (1.8.3)
     little-plugger (1.1.4)
     logging (1.8.2)
       little-plugger (>= 1.1.3)
       multi_json (>= 1.8.4)
-    mini_portile2 (2.0.0)
-    multi_json (1.11.2)
-    nokogiri (1.6.7.2)
-      mini_portile2 (~> 2.0.0.rc2)
+    mini_portile2 (2.1.0)
+    multi_json (1.12.1)
+    nokogiri (1.6.8.1)
+      mini_portile2 (~> 2.1.0)
+    synapse (0.13.8)
+      aws-sdk (~> 1.39)
+      docker-api (~> 1.7)
+      logging (~> 1.8)
+      zk (~> 1.9.4)
     zk (1.9.6)
       zookeeper (~> 1.4.0)
     zookeeper (1.4.11)
@@ -38,7 +32,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  synapse!
+  synapse (~> 0.13.8)
 
 BUNDLED WITH
-   1.10.6
+   1.13.6

--- a/README.md
+++ b/README.md
@@ -12,5 +12,20 @@
 
 ## Usage
 
+1. Put your config file in `conf/config.json`
 1. `docker build -t quay.io/democracyworks/synapse-balancer .`
 1. `docker run -d -p 60800:80 quay.io/democracyworks/synapse-balancer`
+
+### Multiple configs
+
+If you want to support more than one config in different environments, you
+have a couple of different options:
+
+1. Bake in multiple config files and choose one at runtime:
+    1. Put your configs (named anything you want) in the `conf` dir.
+    1. Build a new Docker image to pick up your configs.
+    1. Append the name of your config file to the end of the docker run command
+       (WITHOUT the `conf/` prefix).
+1. Mount your config(s) as a volume:
+    1. In your docker run command, add a `--volume /path/to/your/configs:/usr/src/synapse-balancer/conf` and then append
+    the filename of the config file you want to run to your docker run command.

--- a/conf/bsprod.json
+++ b/conf/bsprod.json
@@ -1,0 +1,112 @@
+{
+  "services": {
+    "address-works": {
+      "discovery": {
+        "method": "docker",
+        "servers": [{
+          "name": "coreos-host",
+          "host": "172.17.0.1",
+          "port": 2375
+        }],
+        "image_name": "quay.io/democracyworks/address-works",
+        "container_port": 8080,
+        "check_interval": 5
+      },
+      "haproxy": {
+        "port": 8082,
+        "server_options": "check inter 2 rise 3 fall 2",
+        "listen": [
+          "mode http"
+        ]
+      }
+    },
+    "ballot-scout": {
+      "discovery": {
+        "method": "docker",
+        "servers": [{
+          "name": "coreos-host",
+          "host": "172.17.0.1",
+          "port": 2375
+        }],
+        "image_name": "quay.io/democracyworks/ballot-scout",
+        "container_port": 8080,
+        "check_interval": 5
+      },
+      "haproxy": {
+        "port": 8080,
+        "server_options": "check inter 2 rise 3 fall 2",
+        "listen": [
+          "mode http"
+        ]
+      }
+    }
+  },
+  "haproxy": {
+    "reload_command": "haproxy -f /etc/haproxy/haproxy.cfg -p /var/run/haproxy.pid -sf $(cat /var/run/haproxy.pid)",
+    "config_file_path": "/etc/haproxy/haproxy.cfg",
+    "socket_file_path": "/var/haproxy/stats.sock",
+    "do_writes": true,
+    "do_reloads": true,
+    "do_socket": false,
+    "global": [
+      "daemon",
+      "user haproxy",
+      "group haproxy",
+      "maxconn 4096",
+      "ulimit-n 8207",
+      "log     127.0.0.1 local0",
+      "log     127.0.0.1 local1 notice",
+      "stats   socket /var/haproxy/stats.sock mode 666 level admin"
+    ],
+    "defaults": [
+      "log      global",
+      "option   dontlognull",
+      "maxconn  2000",
+      "retries  3",
+      "timeout  connect 5s",
+      "timeout  client  1m",
+      "timeout  server  10m",
+      "option   redispatch",
+      "balance  roundrobin"
+    ],
+    "extra_sections": {
+      "listen stats": [
+        "mode http",
+        "bind *:8080",
+        "log global",
+        "maxconn 10",
+        "stats enable",
+        "stats refresh 30s",
+        "stats show-node",
+        "stats uri /stats"
+      ],
+      "frontend http-in": [
+        "mode http",
+        "bind *:80",
+        "http-response add-header X-Via %[env(HOSTNAME)]",
+        "capture request header Host len 64",
+        "acl is_ballot_scout hdr_end(host) -i api.ballotscout.org",
+        "use_backend ballot_scout if is_ballot_scout",
+        "acl is_address hdr_end(host) -i api-int.ballotscout.org",
+        "use_backend address if is_address"
+      ],
+      "backend ballot_scout": [
+        "mode http",
+        "reqrep ^([^\\ ]*)\\ (.+)    \\1\\ \\2",
+        "timeout server 10m",
+        "balance roundrobin",
+        "option httpclose",
+        "option forwardfor",
+        "server local localhost:8080 maxconn 32"
+      ],
+      "backend address": [
+        "mode http",
+        "reqrep ^([^\\ ]*)\\ (.+)    \\1\\ \\2",
+        "balance roundrobin",
+        "option httpclose",
+        "option forwardfor",
+        "server local localhost:8082 maxconn 32"
+      ]
+    }
+  }
+}

--- a/conf/tvprod.json
+++ b/conf/tvprod.json
@@ -1,25 +1,5 @@
 {
   "services": {
-    "wildfly": {
-      "discovery": {
-        "method": "docker",
-        "servers": [{
-          "name": "coreos-host",
-          "host": "172.17.0.1",
-          "port": 2375
-        }],
-        "image_name": "quay.io/democracyworks/wildfly",
-        "container_port": 8080,
-        "check_interval": 5
-      },
-      "haproxy": {
-        "port": 8081,
-        "server_options": "check inter 2s rise 3 fall 2",
-        "listen": [
-          "mode http"
-        ]
-      }
-    },
     "address-works": {
       "discovery": {
         "method": "docker",
@@ -285,12 +265,8 @@
         "bind *:80",
         "http-response add-header X-Via %[env(HOSTNAME)]",
         "capture request header Host len 64",
-        "acl is_ballot_scout hdr_end(host) -i ballotscout.org",
-        "use_backend ballot_scout if is_ballot_scout",
         "acl is_address hdr_end(host) -i api-int.turbovote.org",
         "use_backend address if is_address",
-        "acl is_sendgrid_monitor hdr_end(host) -i sendgrid-monitor.democracy.works",
-        "use_backend sendgrid_monitor if is_sendgrid_monitor",
         "acl is_online_voter_reg_api hdr_end(host) -i online-voter-reg-api.turbovote.org",
         "use_backend online_voter_reg_api if is_online_voter_reg_api",
         "acl is_api_server hdr_end(host) -i api.turbovote.org",
@@ -314,15 +290,6 @@
         "use_backend election_mail_api if is_api_server is_election_mail_api",
         "acl is_turbovote_admin_api url_beg -i /turbovote-admin",
         "use_backend turbovote_admin_api if is_api_server is_turbovote_admin_api"
-      ],
-      "backend ballot_scout": [
-        "mode http",
-        "reqrep ^([^\\ ]*)\\ (.+)    \\1\\ /ballot-scout\\2",
-        "timeout server 10m",
-        "balance roundrobin",
-        "option httpclose",
-        "option forwardfor",
-        "server local localhost:8081 maxconn 32"
       ],
       "backend address": [
         "mode http",

--- a/script/deploy
+++ b/script/deploy
@@ -24,6 +24,7 @@ IMAGE_TAG=$(echo $DOCKER_IMAGE | awk -F: '{print $2}')
 
 echo '--- updating fleet service template'
 perl -p -i -e "s/^Environment=VERSION=.+$/Environment=VERSION=${IMAGE_TAG}/" synapse-balancer@.service
+perl -p -i -e "s/^Environment=DEPLOY_ENV=.*$/Environment=DEPLOY_ENV=${DEPLOY_ENV}/" synapse-balancer@.service
 
 fleetctl destroy synapse-balancer@.service || true # may not exist
 fleetctl submit synapse-balancer@.service

--- a/script/deploy
+++ b/script/deploy
@@ -6,6 +6,11 @@ if [[ -n $1 ]]; then
   DEPLOY_ENV=$1
 fi
 
+if [[ -z $DEPLOY_ENV ]]; then
+  echo "DEPLOY_ENV is required (can be given as first arg to script)"
+  exit 1
+fi
+
 if [[ "${BUILDKITE_PULL_REQUEST}" != "false" ]]; then
   echo "Not deploying because this is a pull request"
   exit 0

--- a/start-synapse.sh
+++ b/start-synapse.sh
@@ -4,4 +4,9 @@ set -x
 
 CONFIG=$1
 
+if [[ -z $CONFIG ]]; then
+  echo "CONFIG is required (can be given as first arg to script)"
+  exit 1
+fi
+
 exec bundle exec synapse --conf=conf/$CONFIG

--- a/start-synapse.sh
+++ b/start-synapse.sh
@@ -1,2 +1,7 @@
 #!/bin/sh
-exec bundle exec synapse --conf=conf.json
+
+set -x
+
+CONFIG=$1
+
+exec bundle exec synapse --conf=conf/$CONFIG

--- a/synapse-balancer@.service
+++ b/synapse-balancer@.service
@@ -12,9 +12,10 @@ TimeoutStartSec=10m
 TimeoutStopSec=10m
 
 Environment=DOCKER_REPO=quay.io/democracyworks/synapse-balancer
-Environment=VERSION=newprod
+Environment=VERSION=master
 Environment=CONTAINER=synapse-balancer
 Environment=HOME=/root
+Environment=DEPLOY_ENV=
 
 ExecStartPre=-/usr/bin/docker kill ${CONTAINER}
 ExecStartPre=-/usr/bin/docker rm ${CONTAINER}
@@ -24,7 +25,7 @@ ExecStartPre=/usr/bin/docker pull ${DOCKER_REPO}:${VERSION}
 ExecStart=/bin/bash -c 'docker run --name ${CONTAINER} --hostname %H \
   --publish 60080:80 \
   --publish 58080:8080 \
-  ${DOCKER_REPO}:${VERSION}'
+  ${DOCKER_REPO}:${VERSION} ${DEPLOY_ENV}.json'
 
 ExecStop=/usr/bin/docker stop ${CONTAINER}
 


### PR DESCRIPTION
In order to better support separate Ballot Scout and TurboVote clusters (as well as future on-demand environments), we need to have more ability to set our config at runtime. There are a lot of different ways we could do that, but this seemed like a simple step in that direction for now.

Since I was in here anyway, I also discovered that we could un-fork synapse and get back on the official upstream.

This targets the `bsprod-deploy` branch which will start out deploying to the new WildFly-free Ballot Scout cluster (once it exists) as a way to better test all these changes before rolling them out to the TurboVote cluster.

Part of [this card](https://www.pivotaltracker.com/story/show/135654349)